### PR TITLE
JWT auth lookup change

### DIFF
--- a/gateway/mw_jwt.go
+++ b/gateway/mw_jwt.go
@@ -523,10 +523,8 @@ func (k *JWTMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Request, _
 	}
 
 	if config.UseCookie {
-		authCookie, err := r.Cookie(config.AuthHeaderName)
-		if err != nil {
-			rawJWT = ""
-		} else {
+		authCookie, err := r.Cookie(config.CookieName)
+		if err == nil {
 			rawJWT = authCookie.Value
 		}
 	}


### PR DESCRIPTION
Changelog 
 - config.AuthHeaderName is the default lookup for JWT token 
 - use config.CookieName iff config.UseCookie is set and value(config.CookieName) is not empty  
     
     