### PR TITLE
disable nopCloseRequestBody()

### DIFF
--- a/gateway/mw_go_plugin.go
+++ b/gateway/mw_go_plugin.go
@@ -124,7 +124,7 @@ func (m *GoPluginMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Reque
 	// prepare data to call Go-plugin function
 
 	// make sure request's body can be re-read again
-	nopCloseRequestBody(r)
+	//nopCloseRequestBody(r)
 
 	// wrap ResponseWriter to check if response was sent
 	rw := &customResponseWriter{

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -1284,7 +1284,13 @@ func (_ mainHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	reloadMu.Unlock()
 
 	// make request body to be nopCloser and re-readable before serve it through chain of middlewares
-	nopCloseRequestBody(r)
+
+	// nuchat - we do not enticiapte body tranfforamtion in any middleware
+	// this code has memory leak
+	// if you are writing go plugin with body transaformation -- it WON'T work
+	// please talk to APIC security team
+	//nopCloseRequestBody(r)
+
 	mainRouter.ServeHTTP(w, r)
 }
 


### PR DESCRIPTION
Changelog 
- disabling nopCloseRequestBody(). It has memory leak and is only used during body transformation

pprof analysis 
```
Showing nodes accounting for 8GB, 98.92% of 8.09GB total
Dropped 246 nodes (cum <= 0.04GB)
Showing top 10 nodes out of 13
      flat  flat%   sum%        cum   cum%
       8GB 98.92% 98.92%        8GB 98.92%  bytes.makeSlice
         0     0% 98.92%     8.01GB 98.97%  bytes.(*Buffer).ReadFrom
         0     0% 98.92%        8GB 98.92%  bytes.(*Buffer).grow
         0     0% 98.92%        8GB 98.96%  github.com/TykTechnologies/tyk/gateway.copyBody
         0     0% 98.92%        8GB 98.96%  github.com/TykTechnologies/tyk/gateway.copyRequest
         0     0% 98.92%     8.04GB 99.35%  github.com/TykTechnologies/tyk/gateway.mainHandler.ServeHTTP
         0     0% 98.92%        8GB 98.96%  github.com/TykTechnologies/tyk/gateway.nopCloseRequestBody
         0     0% 98.92%     0.06GB  0.78%  github.com/TykTechnologies/tyk/vendor/github.com/gorilla/mux.(*Router).ServeHTTP
         0     0% 98.92%        8GB 98.96%  io.Copy
         0     0% 98.92%        8GB 98.96%  io.copyBuffer
```